### PR TITLE
Add Pre-Build, Post-Build, and Post-Link Events

### DIFF
--- a/packages/core/src/fields/buildevents.ts
+++ b/packages/core/src/fields/buildevents.ts
@@ -1,0 +1,39 @@
+import { APIAcceptedTypes } from "../api";
+import { APIBehaviorOnAccept, FieldAPIInfo, FieldRegistry } from "./fields";
+
+const preBuildEventsInfo: FieldAPIInfo = {
+    name: 'preBuildEvents',
+    accepts: APIAcceptedTypes.List(APIAcceptedTypes.String),
+    expectedArgumentCount: 1,
+    allowedInScopes: ['project', 'when', 'block'],
+    acceptedArguments: [],
+    acceptBehavior: APIBehaviorOnAccept.Merge,
+    inherited: true,
+    isFiles: false
+};
+
+const postBuildEventsInfo: FieldAPIInfo = {
+    name: 'postBuildEvents',
+    accepts: APIAcceptedTypes.List(APIAcceptedTypes.String),
+    expectedArgumentCount: 1,
+    allowedInScopes: ['project', 'when', 'block'],
+    acceptedArguments: [],
+    acceptBehavior: APIBehaviorOnAccept.Merge,
+    inherited: true,
+    isFiles: false
+};
+
+const postLinkEventsInfo: FieldAPIInfo = {
+    name: 'postLinkEvents',
+    accepts: APIAcceptedTypes.List(APIAcceptedTypes.String),
+    expectedArgumentCount: 1,
+    allowedInScopes: ['project', 'when', 'block'],
+    acceptedArguments: [],
+    acceptBehavior: APIBehaviorOnAccept.Merge,
+    inherited: true,
+    isFiles: false
+};
+
+FieldRegistry.get().register(preBuildEventsInfo);
+FieldRegistry.get().register(postBuildEventsInfo);
+FieldRegistry.get().register(postLinkEventsInfo);

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -1,3 +1,4 @@
+export * from './buildevents';
 export * from './configurations';
 export * from './defines';
 export * from './dependson';


### PR DESCRIPTION
Adds API functions for Pre-Build, Post-Build, and Post-Link actions.  Closes #1 

```js
preBuildEvents([
  'action1',
  'action2'
]);

postBuildEvents([
  'action3'
]);

postLinkEvents([
  'action4'
]);
```